### PR TITLE
fix(market): refresh before update, fix #226

### DIFF
--- a/plugins/market/src/node/index.ts
+++ b/plugins/market/src/node/index.ts
@@ -108,6 +108,8 @@ export function apply(ctx: Context, config: Config) {
           return names
         }
 
+        // refresh dependencies
+        ctx.installer.refresh(true)
         const deps = await ctx.installer.getDeps()
         names = await getPackages(names)
         names = names.filter((name) => {


### PR DESCRIPTION
> [!note]
> This is a PR that has not been locally tested because I am unable to fully build a local WebUI environment. I can only speculate the usage of this API based on the `market/refresh` events.

Fix the plugin registry does not refresh when the `plugin.upgrade` command is used.