### PR TITLE
fix: Windows 11 is recognized as Windows 10

### DIFF
--- a/plugins/status/package.json
+++ b/plugins/status/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@koishijs/console": "^5.17.1",
-    "envinfo": "^7.10.0",
+    "envinfo": "^7.11.0",
     "throttle-debounce": "^3.0.1",
     "which-pm-runs": "^1.1.0"
   }


### PR DESCRIPTION
fixes #196