### PR TITLE
fix(console): fix Events<Context> missing 'router/ready'

### DIFF
--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -18,6 +18,7 @@ declare module 'koishi' {
   }
 
   interface Events {
+    'router/ready'(): Awaitable<void>
     'console/connection'(client: Client): void
     'console/intercept'(client: Client, listener: DataService.Options): Awaitable<boolean>
   }


### PR DESCRIPTION
[this update](https://github.com/koishijs/webui/commit/14793f1e0d3f50771483c87f8392c6633efb742e) add 'router/ready' but no type，error when running build script