### PR TITLE
fix(commands): make CommandManager.config indepedent from its scope.config

### DIFF
--- a/plugins/commands/src/index.ts
+++ b/plugins/commands/src/index.ts
@@ -82,6 +82,7 @@ export class CommandManager {
   public snapshots: Dict<Snapshot> = Object.create(null)
 
   constructor(private ctx: Context, private config: Dict<Config>) {
+    this.config = CommandManager.schema(config)
     this.refresh = this.ctx.debounce(() => {
       this._cache = null
       this.entry?.refresh()


### PR DESCRIPTION
CommandManager.config 和 CommandManager.ctx.scope.config 在初始化时为同一值，这将导致 CommandManager.update() 先重写配置项后触发 ctx.scope.update()， 此时 ctx.scope.config 已经被修改，导致 internal/before-update 中无法区分是否改动。 而 ctx.scope.update() 中调用了 schema()， 因此后续并不会出现问题。因而此pr在初始化时强制让二者独立来避免此问题。