### PR TITLE
Update index.ts - 在`command-updated`事件里添加执行 `this.refresh()`

### DIFF
--- a/plugins/commands/src/index.ts
+++ b/plugins/commands/src/index.ts
@@ -107,6 +107,7 @@ export class CommandManager {
         this.snapshots[command.name].pending = null
         this._teleport(command, parent)
       }
+      this.refresh()
     })
 
     ctx.on('command-updated', (cmd) => {


### PR DESCRIPTION
在开启指令插件时，注册的指令有时不会显示出来，

但是关开一下commands插件之后 就会正常显示了

---

在此处加上 `this.refresh()` 可以很好的解决这一问题，

能让插件注册的指令 正常显示出来

---

效果对比：



![recording](https://github.com/user-attachments/assets/6ae525ea-f12f-4469-a698-38ced20c31dd)



![recording](https://github.com/user-attachments/assets/b1f22729-685f-4323-a50b-13bfd7455f8a)


