### PR TITLE
修复console任意文件读取漏洞

### DIFF
--- a/plugins/console/src/node/index.ts
+++ b/plugins/console/src/node/index.ts
@@ -147,7 +147,11 @@ class NodeConsole extends Console {
         const [key] = name.slice(8).split('/', 1)
         if (this.entries[key]) {
           const files = makeArray(this.getFiles(this.entries[key].files))
-          const filename = files[0] + name.slice(8 + key.length)
+          let filename = files[0] + name.slice(8 + key.length)
+          filename = resolve(this.root, filename)
+          if (!filename.startsWith(this.root) && !filename.includes('node_modules')) {
+            return ctx.status = 403
+          }
           ctx.type = extname(filename)
           if (this.config.devMode || ctx.type !== 'application/javascript') {
             return sendFile(filename)


### PR DESCRIPTION
原代码中如果路径名以@plugin-开头则不对路径做任何校验，不是js文件的话(如koishi.yml)能直接sendFile(filename)返回
<img width="1043" height="433" alt="image" src="https://github.com/user-attachments/assets/0d75e57b-2bf7-4bb9-b0d4-f5d9aed991ba" />
koishi的后台账号密码完全明文写在koishi.yml中，因此一旦读取到能够直接进入后台进行更加高危的操作比如任意代码执行
<img width="2074" height="1238" alt="image" src="https://github.com/user-attachments/assets/0476ceaa-55c0-4441-b805-767792fec28b" />
服务端代码执行示例（无需额外安装任何插件）：
<img width="2560" height="1540" alt="f7e31ede932851404f8f02baec1067be" src="https://github.com/user-attachments/assets/372a419a-7de1-4f18-ad7d-898cc9979bc5" />
修复方案对插件文件先目录规范化后去除所有./和../，再判断目录位置是否合法
