### PR TITLE
feat(market): add startup delay option

### DIFF
--- a/plugins/market/src/node/locales/schema.de-DE.yml
+++ b/plugins/market/src/node/locales/schema.de-DE.yml
@@ -6,4 +6,5 @@ search:
   $description: 搜索设置
   endpoint: 用于搜索插件市场的网址。默认跟随插件源设置。
   timeout: 搜索插件市场的超时时间。
+  delay: 延迟多久后再开始首次同步。
   proxyAgent: 用于搜索插件市场的代理。

--- a/plugins/market/src/node/locales/schema.en-US.yml
+++ b/plugins/market/src/node/locales/schema.en-US.yml
@@ -6,4 +6,5 @@ search:
   $description: 搜索设置
   endpoint: 用于搜索插件市场的网址。默认跟随插件源设置。
   timeout: 搜索插件市场的超时时间。
+  delay: 延迟多久后再开始首次同步。
   proxyAgent: 用于搜索插件市场的代理。

--- a/plugins/market/src/node/locales/schema.fr-FR.yml
+++ b/plugins/market/src/node/locales/schema.fr-FR.yml
@@ -6,4 +6,5 @@ search:
   $description: 搜索设置
   endpoint: 用于搜索插件市场的网址。默认跟随插件源设置。
   timeout: 搜索插件市场的超时时间。
+  delay: 延迟多久后再开始首次同步。
   proxyAgent: 用于搜索插件市场的代理。

--- a/plugins/market/src/node/locales/schema.ja-JP.yml
+++ b/plugins/market/src/node/locales/schema.ja-JP.yml
@@ -6,4 +6,5 @@ search:
   $description: 搜索设置
   endpoint: 用于搜索插件市场的网址。默认跟随插件源设置。
   timeout: 搜索插件市场的超时时间。
+  delay: 延迟多久后再开始首次同步。
   proxyAgent: 用于搜索插件市场的代理。

--- a/plugins/market/src/node/locales/schema.ru-RU.yml
+++ b/plugins/market/src/node/locales/schema.ru-RU.yml
@@ -6,4 +6,5 @@ search:
   $description: 搜索设置
   endpoint: 用于搜索插件市场的网址。默认跟随插件源设置。
   timeout: 搜索插件市场的超时时间。
+  delay: 延迟多久后再开始首次同步。
   proxyAgent: 用于搜索插件市场的代理。

--- a/plugins/market/src/node/locales/schema.zh-CN.yml
+++ b/plugins/market/src/node/locales/schema.zh-CN.yml
@@ -7,4 +7,5 @@ search:
   $description: 搜索设置
   endpoint: 用于搜索插件市场的网址。默认跟随插件源设置。
   timeout: 搜索插件市场的超时时间。
+  delay: 延迟多久后再开始首次同步。
   proxyAgent: 用于搜索插件市场的代理。

--- a/plugins/market/src/node/locales/schema.zh-TW.yml
+++ b/plugins/market/src/node/locales/schema.zh-TW.yml
@@ -6,4 +6,5 @@ search:
   $description: 搜尋設定
   endpoint: 用於搜尋外掛程式市場的網址。默認跟隨外掛程式源設置。
   timeout: 搜尋外掛程式市場的超時時間。
+  delay: 延遲多久後再開始首次同步。
   proxyAgent: 用於搜尋外掛程式市場的代理。

--- a/plugins/market/src/node/market.ts
+++ b/plugins/market/src/node/market.ts
@@ -1,4 +1,4 @@
-import { Context, Dict, HTTP, Schema, Time } from 'koishi'
+import { Context, Dict, HTTP, Schema, Time, sleep } from 'koishi'
 import Scanner, { SearchObject, SearchResult } from '@koishijs/registry'
 import { MarketProvider as BaseMarketProvider } from '../shared'
 
@@ -29,6 +29,9 @@ class MarketProvider extends BaseMarketProvider {
     this.fullCache = {}
     this.tempCache = {}
     if (refresh) this.ctx.installer.refresh(true)
+    if (!refresh && this.config.delay) {
+      await sleep(this.config.delay)
+    }
     await this.prepare()
     super.start()
   }
@@ -101,11 +104,13 @@ namespace MarketProvider {
   export interface Config {
     endpoint?: string
     timeout?: number
+    delay?: number
   }
 
   export const Config: Schema<Config> = Schema.object({
     endpoint: Schema.string().role('link'),
     timeout: Schema.number().role('time').default(Time.second * 30),
+    delay: Schema.number().role('time').default(0).description('执行首次同步前的等待时间。'),
     proxyAgent: Schema.string().role('link'),
   })
 }


### PR DESCRIPTION
部分镜像源插件，如 [storeluna](https://github.com/shangxueink/koishi-shangxue-apps/tree/main/plugins/storeluna) ，在重启时没有market起的快（前后大概差几秒），导致market插件报错，希望通过给market增加延时选项，来规避此问题（用户可选开启）

```
2025-11-17 15:14:26 [I] loader apply plugin group:cron
2025-11-17 15:14:26 [I] loader apply plugin cron:zjw6ju
2025-11-17 15:14:26 [I] loader apply plugin group:nqn4w8
2025-11-17 15:14:26 [I] loader apply plugin lmarena:7ostab
2025-11-17 15:14:26 [I] loader apply plugin worldnews:i2lm39
2025-11-17 15:14:26 [I] pow cache init 300000
2025-11-17 15:14:27 [I] puppeteer chrome executable found at /usr/bin/chromium
2025-11-17 15:14:27 [I] server server listening at http://0.0.0.0:5140
2025-11-17 15:14:27 [I] console webui is available at http://127.0.0.1:5140
2025-11-17 15:14:27 [W] market SocketError: other side closed
                            at Socket.onHttpSocketEnd (/koishi/node_modules/cheerio/node_modules/undici/lib/dispatcher/client-h1.js:904:22)
                            at Socket.emit (node:events:531:35)
                            at endReadableNT (node:internal/streams/readable:1696:12)
                            at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
2025-11-17 15:14:27 [W] market TypeError: fetch failed
                            at node:internal/deps/undici/undici:13178:13
                            at async [cordis.invoke] (/koishi/node_modules/@cordisjs/plugin-http/lib/index.cjs:325:19)
                            at async Proxy.<anonymous> (/koishi/node_modules/@cordisjs/plugin-http/lib/index.cjs:178:26)
                            at async MarketProvider.collect (/koishi/node_modules/@koishijs/plugin-market/lib/node/index.js:378:22)
                            at async MarketProvider.start (/koishi/node_modules/@koishijs/plugin-market/lib/node/index.js:369:5)
                            at async /koishi/node_modules/@cordisjs/core/lib/index.cjs:1213:7
2025-11-17 15:14:27 [W] market Error: fetch http://x.x.x.x:5140/storeluna/index.json failed
                            at /koishi/node_modules/@cordisjs/plugin-http/lib/index.cjs:327:23
                            at async [cordis.invoke] (/koishi/node_modules/@cordisjs/plugin-http/lib/index.cjs:325:19)
                            at async Proxy.<anonymous> (/koishi/node_modules/@cordisjs/plugin-http/lib/index.cjs:178:26)
                            at async MarketProvider.collect (/koishi/node_modules/@koishijs/plugin-market/lib/node/index.js:378:22)
                            at async MarketProvider.start (/koishi/node_modules/@koishijs/plugin-market/lib/node/index.js:369:5)
                            at async /koishi/node_modules/@cordisjs/core/lib/index.cjs:1213:7

```
